### PR TITLE
45 fix flip vehicle

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -171,8 +171,8 @@ ace_frag_spallEnabled = false;
 ace_frag_spallIntensity = 0.1;
 
 // ACE G-Forces
-ace_gforces_coef = 0.5;
-ace_gforces_enabledFor = 1;
+ace_gforces_coef = 0;
+ace_gforces_enabledFor = 0;
 
 // ACE Goggles
 ace_goggles_drawOverlay = true;

--- a/addons/missions/functions/fnc_flipVehicle.sqf
+++ b/addons/missions/functions/fnc_flipVehicle.sqf
@@ -1,16 +1,16 @@
 #include "..\script_component.hpp"
 /*
- * Authors: You
- * Description.
+ * Authors: Archer
+ * Adds a hold action to a vehicle that allows a player to flip it back upright.
  *
  * Arguments:
- * 0: Argument (optional, default: value) <OBJECT>
+ * 0: Vehicle to add the flip action to <OBJECT>
  *
  * Return Value:
- * Return description <NONE>
+ * Whether the hold action was successfully added <BOOL>
  *
  * Example:
- * [params] call PREFIX_missions_fnc_flipVehicle
+ * [_this] call ar_missions_fnc_flipVehicle
  *
  * Public: No
  */
@@ -28,7 +28,7 @@ if(isNull _vehicle) exitWith {
  1 : Test if the vehicles is alive.
  2 : Test if the player doing the holdAction has a distance of 8 meters maximum
  3 : Test if the vehicle is flipped.
- 4 : Test if the vehicle is at least from 5 meter from the ground
+ 4 : Test if the vehicle is less than 5 meter from the ground
  5 : Test if the player (_this) is on foot, Enable the trigger when the player is on foot
  6 : Test if the vehicle is on water (if it is can't flip).
  7 : Test if the crew has exited the vehicle.
@@ -51,8 +51,7 @@ private _canBeFlipped = "(alive _target) &&
 	{}, // CodeProgress
 	{	
 	params ["_target", "_caller", "_actionId", "_arguments"];
-    private _up = vectorUp _target;
-    _target setVectorUp [_up select 0, _up select 1, 1];
+    _target setVectorUp [0, 0, 1];
 	_target setPosATL ((getPosATL _target) vectorAdd [0,0,1.5]);
 	
 }, // CodeCompleted

--- a/addons/missions/functions/fnc_flipVehicle.sqf
+++ b/addons/missions/functions/fnc_flipVehicle.sqf
@@ -24,23 +24,44 @@ if(isNull _vehicle) exitWith {
 	WARNING("fnc_flipVehicle: No vehicle provided");
 	false;
 };
+/*
+ 1 : Test if the vehicles is alive.
+ 2 : Test if the player doing the holdAction has a distance of 8 meters maximum
+ 3 : Test if the vehicle is flipped.
+ 4 : Test if the vehicle is at least from 5 meter from the ground
+ 5 : Test if the player (_this) is on foot, Enable the trigger when the player is on foot
+ 6 : Test if the vehicle is on water (if it is can't flip).
+ 7 : Test if the crew has exited the vehicle.
+*/
+ 
+private _canBeFlipped = "(alive _target) && 
+					  ((_this distance _target) <= 8) &&
+                      ((vectorUp _target) select 2 < 0)  && 
+                      (((getPosATL _target)select 2) <= 5) && 
+                      ((vehicle _this) == _this) &&
+                      !(surfaceIsWater (position _target)) &&
+					  ((crew _target) isEqualTo [])";
 
-_vehicle addAction [LLSTRING(FLIPVEHICLE), 
-{
+[
+	_vehicle,
+	LLSTRING(FLIPVEHICLE),
+	"\a3\data_f_destroyer\data\UI\IGUI\Cfg\holdactions\holdAction_unloadVehicle_ca.paa", "\a3\data_f_destroyer\data\UI\IGUI\Cfg\holdactions\holdAction_unloadVehicle_ca.paa",
+	_canBeFlipped, _canBeFlipped,
+	{}, // CodeStart
+	{}, // CodeProgress
+	{	
 	params ["_target", "_caller", "_actionId", "_arguments"];
-
     private _up = vectorUp _target;
     _target setVectorUp [_up select 0, _up select 1, 1];
 	_target setPosATL ((getPosATL _target) vectorAdd [0,0,1.5]);
-
-},
-nil,
-1.5,
-true,
-true,
-"",
-"(vectorUp _target) select 2 < 0",
-8
-];
+	
+}, // CodeCompleted
+	{}, // CodeInterrupted
+	[], // Arguments
+	5, // Duration
+	nil, // Priority
+	false, // removeCompleted
+	false // ShowUnconscious
+] call BIS_fnc_holdActionAdd;
 
 true


### PR DESCRIPTION
Ajout de nouvelles conditions pour le flip de véhicules afin de s'assurer que le script s’exécute dans les bonnes conditions, notamment :

- Si le véhicule est en vie.
- Si le joueurs qui fait l'action est a moins de 8m.
- Si le véhicule est bien a l'envers.
- Si le véhicule est a moins de 5 mètre du sol.
- Si le joueur qui active l'action est a pied.
- Si le véhicules n'est pas sur l'eau ou sous l'eau.
- Si le véhicule est vide.